### PR TITLE
Update Full_Workflow_SCN_vs_NICU.Rmd

### DIFF
--- a/Scripts/Full_Workflow_SCN_vs_NICU.Rmd
+++ b/Scripts/Full_Workflow_SCN_vs_NICU.Rmd
@@ -478,7 +478,7 @@ prevdf %>%
 ```
 
 ### Aggolmerate taxa.
- - Combine features that descend from the same genus as most species have not been identified due to the poor sequencing depth in 16S.
+ - Combine features that descend from the same genus as most species have not been identified due to the poor sequencing depth in 16S. It is due to the length of the fragment amplified from the 16SrRNA gene. Sequencing depth affects diversity meassures. 
  - Can check how many genera would be present after filtering by running `length(get_taxa_unique(ps2, taxonomic.rank = "Genus"))`, and `ntaxa(ps3)` will give the number of post agglomeration taxa.
  
 ```{r, warning=F, message=F, results='hide'}


### PR DESCRIPTION
Comment on line 481. 

Combine features that descend from the same genus as most species have not been identified due to the poor sequencing depth in 16S. It is due to the length of the fragment amplified from the 16SrRNA gene. Sequencing depth affects diversity measures. 